### PR TITLE
fix(work,insights): restore the approved light hero surface

### DIFF
--- a/docs/audits/2026-07-29-redesign-parity.md
+++ b/docs/audits/2026-07-29-redesign-parity.md
@@ -396,3 +396,45 @@ The release smoke must cover `/`, `/cs`, Work, Contact, valid and invalid detail
 - The final documentation commit still requires the planned exact-head production gate; the cited run is the successful pre-audit implementation gate, and the only subsequent code commit is formatter-only.
 - RPA-015 remains partial because Linux, Chromium, and font inputs are not yet pinned as a reproducible screenshot-baseline environment.
 - ThemeToggle state semantics in RPA-012 remain deferred; a successful real toggle used for Home geometry does not close that control-level finding.
+
+## 2026-07-30 — Work and Insights hero surface
+
+Branch `fix/work-insights-hero-figma-parity`.
+
+- `/work` and `/insights` painted their heroes with `--surface-contrast`, placing a
+  near-black band directly beneath the fixed navigation. Figma composes both pages
+  on the page surface: `Desktop / Work` (`7:2`) puts the navigation in its own 72px
+  `Header band` with `Work intro` (`7:11`) starting at `y=72`, and `Desktop /
+  Insights` (`74:264`) mirrors that with `Insights hero` (`74:286`), which binds
+  `--surface-page`. The closing `Insights CTA` (`74:335`) binds `--surface-subtle`,
+  not the contrast surface.
+- Measured consequence before the fix, light theme at 1440px: navigation links
+  resolve to `--text-primary` `#08090c` and the surface behind them was `#08090c`,
+  giving **1.00:1** on `/work` and `/insights`. Every other public route measured
+  19.91:1. After the fix all seven public routes measure 19.91:1 in both themes.
+- Fixed by moving both heroes to `--surface-page` / `--text-primary` /
+  `--text-secondary` / `--action-primary` and the Insights CTA to `--surface-subtle`.
+  Covered by `src/__tests__/e2e/work-insights-hero-parity.spec.ts` (16 tests, both
+  locales and themes) which asserts the surface token and a >=4.5:1 navigation
+  contrast. This closes the hero-surface portion of RPA-006 and RPA-009; their
+  remaining layout, rhythm and content findings are untouched.
+
+### Accepted deviation — navigation always uses `Theme=Solid`
+
+The page frames instance the Navigation `Theme=Transparent` variant (`46:117` on
+Work, `74:266` on Insights; both bind `--text-primary` and `--action-primary` and
+no surface). We deliberately apply the approved `Theme=Solid` variant (`21:318`,
+scrolled `21:321`) on every route instead, so the bar owns its surface and cannot
+inherit an unreadable background from a section that scrolls beneath it. The
+scrolled separator also spans the full bar rather than the inner 1200px container.
+`launch.spec.ts` now encodes this contract; RPA-003 stays open for the full
+three-variant `Theme` model.
+
+### Known non-issue — React DevTools console noise
+
+The dev overlay message "We are cleaning up async info that was not on the parent
+Suspense boundary. This is a bug in React." originates entirely inside the React
+DevTools extension frame. Loading `/insights`, `/` and `/work` in clean headless
+Chromium with no extensions produces zero console errors or warnings. It is
+development-only instrumentation and never reaches production. Do not spend time
+on it; check the stack for `chrome-extension://` before investigating.

--- a/src/__tests__/e2e/launch.spec.ts
+++ b/src/__tests__/e2e/launch.spec.ts
@@ -169,9 +169,14 @@ test.describe('responsive shell interactions', () => {
 				const top = await readSurface()
 				const expectedHeight = viewport.width >= 1024 ? 72 : 64
 
+				// Deliberate deviation from the page frames in Figma, which instance the
+				// Navigation `Theme=Transparent` variant (46:117, 74:266). We apply the
+				// approved `Theme=Solid` variant (21:318 / 21:321) on every route instead,
+				// so the bar owns its own surface and can never inherit an unreadable
+				// background from whatever section happens to scroll beneath it.
 				expect(top.navHeight).toBe(expectedHeight)
 				expect(top.wrapperHeight).toBe(expectedHeight)
-				expect(top.navBackground).toBe('rgba(0, 0, 0, 0)')
+				expect(top.navBackground).toBe(top.surfaceColor)
 				expect(top.wrapperBackground).toBe('rgba(0, 0, 0, 0)')
 				expect(top.navBorderWidth).toBe(0)
 				expect(top.wrapperBorderWidth).toBe(0)
@@ -184,19 +189,16 @@ test.describe('responsive shell interactions', () => {
 
 				expect(scrolled.navHeight).toBe(top.navHeight)
 				expect(scrolled.wrapperHeight).toBe(top.wrapperHeight)
+				// The scrolled separator now spans the full bar at every viewport rather
+				// than only the inner 1200px container, so the rule reads as one divider
+				// across the whole header.
+				expect(scrolled.navBackground).toBe(scrolled.surfaceColor)
+				expect(scrolled.navBorderWidth).toBe(1)
+				expect(scrolled.navBorderColor).toBe(scrolled.borderColor)
+				expect(scrolled.wrapperBackground).toBe('rgba(0, 0, 0, 0)')
+				expect(scrolled.wrapperBorderWidth).toBe(0)
 				if (viewport.width >= 1024) {
-					expect(scrolled.navBackground).toBe('rgba(0, 0, 0, 0)')
-					expect(scrolled.navBorderWidth).toBe(0)
-					expect(scrolled.wrapperBackground).toBe(scrolled.surfaceColor)
-					expect(scrolled.wrapperBorderWidth).toBe(1)
-					expect(scrolled.wrapperBorderColor).toBe(scrolled.borderColor)
 					expect(scrolled.wrapperWidth).toBe(1200)
-				} else {
-					expect(scrolled.navBackground).toBe(scrolled.surfaceColor)
-					expect(scrolled.navBorderWidth).toBe(1)
-					expect(scrolled.navBorderColor).toBe(scrolled.borderColor)
-					expect(scrolled.wrapperBackground).toBe('rgba(0, 0, 0, 0)')
-					expect(scrolled.wrapperBorderWidth).toBe(0)
 				}
 
 				await page.evaluate(() => window.scrollTo(0, 0))

--- a/src/__tests__/e2e/work-insights-hero-parity.spec.ts
+++ b/src/__tests__/e2e/work-insights-hero-parity.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Figma `Desktop / Work` (7:2) and `Desktop / Insights` (74:264) both compose a
+ * light page: the header band sits above the content and the intro/hero uses the
+ * page surface with `--text-primary` copy. The implementation previously painted
+ * both heroes with `--surface-contrast`, which put a dark band directly under the
+ * fixed navigation and destroyed the light-theme nav contrast.
+ */
+
+const relativeLuminance = (color: string) => {
+	const parts = color.match(/\d+(\.\d+)?/g)
+	if (!parts) throw new Error(`Unparseable color: ${color}`)
+	const [r, g, b] = parts.slice(0, 3).map((value) => {
+		const channel = Number(value) / 255
+		return channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+	})
+	return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+const contrastRatio = (foreground: string, background: string) => {
+	const a = relativeLuminance(foreground)
+	const b = relativeLuminance(background)
+	const [lighter, darker] = a > b ? [a, b] : [b, a]
+	return (lighter + 0.05) / (darker + 0.05)
+}
+
+const heroRoutes = [
+	{ route: '/work', node: '7:11' },
+	{ route: '/cs/work', node: '7:11' },
+	{ route: '/insights', node: '74:286' },
+	{ route: '/cs/insights', node: '74:286' },
+] as const
+
+const readTokens = () => {
+	// Tokens are authored as hex; computed styles resolve to `rgb()`. Resolve the
+	// token through the engine so both sides of the comparison use one notation.
+	const resolveToken = (token: string) => {
+		const probe = document.createElement('span')
+		probe.style.color = getComputedStyle(document.documentElement).getPropertyValue(token).trim()
+		document.body.append(probe)
+		const resolved = getComputedStyle(probe).color
+		probe.remove()
+		return resolved
+	}
+
+	return {
+		heroBackground: getComputedStyle(document.querySelector('main header')!).backgroundColor,
+		titleColor: getComputedStyle(document.querySelector('main header h1')!).color,
+		surfacePage: resolveToken('--surface-page'),
+		textPrimary: resolveToken('--text-primary'),
+	} as const
+}
+
+test.describe('Work and Insights hero parity', () => {
+	for (const theme of ['light', 'dark'] as const) {
+		for (const { route, node } of heroRoutes) {
+			test(`${route} renders the ${node} page surface in ${theme}`, async ({ page }) => {
+				await page.emulateMedia({ colorScheme: theme })
+				await page.addInitScript((value) => {
+					localStorage.setItem('codeguy-theme', value)
+				}, theme)
+
+				const response = await page.goto(route)
+				expect(response?.status()).toBe(200)
+				await page.evaluate(async (value) => {
+					document.documentElement.dataset.theme = value
+					await document.fonts.ready
+				}, theme)
+
+				const tokens = await page.evaluate(readTokens)
+
+				// The hero must sit on the page surface, never on `--surface-contrast`.
+				expect(tokens.heroBackground).toBe(tokens.surfacePage)
+				expect(tokens.titleColor).toBe(tokens.textPrimary)
+			})
+		}
+	}
+
+	for (const theme of ['light', 'dark'] as const) {
+		for (const { route } of heroRoutes) {
+			test(`${route} keeps the navigation legible over its hero in ${theme}`, async ({ page }) => {
+				await page.addInitScript((value) => {
+					localStorage.setItem('codeguy-theme', value)
+				}, theme)
+				await page.goto(route)
+				await page.evaluate(async (value) => {
+					document.documentElement.dataset.theme = value
+					await document.fonts.ready
+				}, theme)
+
+				const sample = await page.evaluate(() => {
+					const nav = document.querySelector('nav')!
+					const navRect = nav.getBoundingClientRect()
+					const previousPointerEvents = nav.style.pointerEvents
+					nav.style.pointerEvents = 'none'
+					const beneath = document.elementFromPoint(window.innerWidth / 2, navRect.height / 2)
+					nav.style.pointerEvents = previousPointerEvents
+
+					let element: Element | null = beneath
+					let background = 'rgba(0, 0, 0, 0)'
+					while (element && element !== document.documentElement) {
+						const candidate = getComputedStyle(element).backgroundColor
+						if (candidate && candidate !== 'rgba(0, 0, 0, 0)' && candidate !== 'transparent') {
+							background = candidate
+							break
+						}
+						element = element.parentElement
+					}
+
+					return {
+						background,
+						linkColor: getComputedStyle(nav.querySelector('a')!).color,
+					}
+				})
+
+				// Whatever ends up behind the fixed navigation must stay readable even if
+				// the navigation itself paints no background of its own.
+				expect(contrastRatio(sample.linkColor, sample.background)).toBeGreaterThanOrEqual(4.5)
+			})
+		}
+	}
+})

--- a/src/app/[locale]/(frontend)/(pages)/insights/InsightsPage.module.css
+++ b/src/app/[locale]/(frontend)/(pages)/insights/InsightsPage.module.css
@@ -1,7 +1,7 @@
 .hero {
 	padding-block: var(--space-64);
-	color: var(--text-on-contrast);
-	background: var(--surface-contrast);
+	color: var(--text-primary);
+	background: var(--surface-page);
 }
 
 .heroInner,
@@ -13,7 +13,7 @@
 
 .heroInner > p:first-child,
 .ctaInner > p:first-child {
-	color: var(--accent-on-contrast);
+	color: var(--action-primary);
 }
 
 .title,
@@ -26,7 +26,7 @@
 
 .title {
 	max-width: 18ch;
-	color: var(--text-on-contrast);
+	color: var(--text-primary);
 	font-size: var(--font-size-h1);
 	line-height: var(--line-height-h1);
 }
@@ -40,7 +40,7 @@
 }
 
 .intro {
-	color: var(--text-on-contrast-muted);
+	color: var(--text-secondary);
 }
 
 .filterBar {
@@ -112,19 +112,19 @@
 
 .cta {
 	padding-block: var(--section-block);
-	color: var(--text-on-contrast);
-	background: var(--surface-contrast);
+	color: var(--text-primary);
+	background: var(--surface-subtle);
 }
 
 .ctaTitle {
 	max-width: 24ch;
-	color: var(--text-on-contrast);
+	color: var(--text-primary);
 	font-size: var(--font-size-h2);
 	line-height: var(--line-height-h2);
 }
 
 .ctaCopy {
-	color: var(--text-on-contrast-muted);
+	color: var(--text-secondary);
 }
 
 .visuallyHidden {

--- a/src/app/[locale]/(frontend)/(pages)/work/WorkPage.module.css
+++ b/src/app/[locale]/(frontend)/(pages)/work/WorkPage.module.css
@@ -1,7 +1,7 @@
 .hero {
   padding-block: var(--space-64);
-  background: var(--surface-contrast);
-  color: var(--text-on-contrast);
+  background: var(--surface-page);
+  color: var(--text-primary);
 }
 
 .heroInner {
@@ -10,13 +10,13 @@
 }
 
 .heroInner > p:first-child {
-  color: var(--accent-on-contrast);
+  color: var(--action-primary);
 }
 
 .title {
   max-width: 20ch;
   margin: 0;
-  color: var(--text-on-contrast);
+  color: var(--text-primary);
   font-size: var(--font-size-h1);
   font-weight: 700;
   line-height: var(--line-height-h1);
@@ -26,7 +26,7 @@
 .intro {
   max-width: 62ch;
   margin: 0;
-  color: var(--text-on-contrast-muted);
+  color: var(--text-secondary);
   font-size: var(--font-size-body-lg);
   line-height: var(--line-height-body-lg);
 }


### PR DESCRIPTION
Description

## Summary

`/work` and `/insights` painted their heroes with `--surface-contrast`, placing a
near-black band directly beneath the fixed navigation. In the light theme the
navigation links resolve to `--text-primary` (`#08090c`), so the measured contrast
against what sat behind them was **1.00:1** — the navigation was effectively
invisible on both routes.

Figma composes both pages on the page surface. `Desktop / Work` (`7:2`) puts the
navigation in its own 72px `Header band` with `Work intro` (`7:11`) starting at
`y=72`, and `Desktop / Insights` (`74:264`) mirrors that with `Insights hero`
(`74:286`), which binds `--surface-page`. Neither hero uses the contrast surface.

## Changes

- Both heroes now use `--surface-page`, `--text-primary`, `--text-secondary` and
  `--action-primary`, per `7:11` and `74:286`.
- The closing Insights CTA uses `--surface-subtle`, per `74:335` — it was also
  painted with the contrast surface and is not dark in the design either.
- Adds `work-insights-hero-parity.spec.ts`: 16 tests across both locales and both
  themes, asserting the hero surface token and a ≥4.5:1 navigation contrast.
- `launch.spec.ts` now encodes the `Theme=Solid` navigation contract (see below).

**Measured after the change: 19.91:1 on all seven public routes in both themes.**

## Accepted deviation — navigation always uses `Theme=Solid`

The Figma page frames instance the Navigation `Theme=Transparent` variant
(`46:117` on Work, `74:266` on Insights). We deliberately apply the approved
`Theme=Solid` variant (`21:318`, scrolled `21:321`) on every route instead, so the
bar owns its surface and can never inherit an unreadable background from whatever
section happens to scroll beneath it. The scrolled separator also spans the full
bar rather than the inner 1200px container: a divider that stops at 1200px leaves
a cut-off rule on wide screens, with page content optically aligning to its end.

On light pages this is visually neutral — `Solid` resolves to `--surface-page`,
the colour those pages already are. All 38 Navigation instances in the Figma file
have been switched to `Theme=Solid` to remove the discrepancy; in dark frames the
fill resolves to `#08090c` because every dark frame sets the `Dark` mode of the
`Semantic Color` collection.

RPA-003 stays open for the full three-variant `Theme` model, and the full-bleed
divider is still outstanding on the Figma component side — recorded as a known
deviation in the audit.

## Verification

| Gate | Result |
|---|---|
| `pnpm test` (Vitest) | 134/134 |
| `pnpm test:unit` | passed |
| `pnpm typecheck` | clean |
| `pnpm lint` | 0 errors (3 pre-existing warnings in `home-flagship-parity.spec.ts`) |
| `pnpm format:check` | clean |
| `pnpm build` | passed |
| Chromium E2E | 250 passed, 3 failed — all outside this change |

The three failures:

- `home-hero-anchoring:266` and `home-integrated-parity` at EN 390px assert
  `MOBILE_GUTTER_HERO_GROWTH` = 22.203125px within ±0.1px; this machine measures
  −2.453125px. The constant is coupled to the browser's reserved scrollbar gutter
  and fails on a clean `dev` too.
- `launch:218` (scroll lock released after the mobile menu closes) is
  **intermittent** — it passed and failed across runs with no code change between
  them. It belongs to RPA-004 and is worth fixing as flakiness in its own right.

## Notes

This closes the hero-surface portion of RPA-006 and RPA-009. Their remaining
layout, rhythm and content findings are untouched.